### PR TITLE
Change Dropdown Box to a Range Bar

### DIFF
--- a/src/web/app/components/question-types/question-edit-answer-form/contribution-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/contribution-question-edit-answer-form.component.html
@@ -9,9 +9,11 @@
     }">
       <span *ngIf='responseDetails.answer === CONTRIBUTION_POINT_NOT_SURE && questionDetails.isNotSureAllowed; else elseBlock'>Not Sure</span>
       <ng-template #elseBlock>
-        <span>Equal Share
-          <span *ngIf='responseDetails.answer > 100'> +{{ responseDetails.answer - 100 }}%</span>
-          <span *ngIf='responseDetails.answer < 100 && responseDetails.answer !== CONTRIBUTION_POINT_NOT_SUBMITTED'> -{{ 100 - responseDetails.answer }}%</span>
+        <span>
+          <span *ngIf='responseDetails.answer === 100'>Equal Share</span>
+          <span *ngIf='responseDetails.answer > 100'>Equal Share +{{ responseDetails.answer - 100 }}%</span>
+          <span *ngIf='responseDetails.answer < 100 && responseDetails.answer !== CONTRIBUTION_POINT_NOT_SUBMITTED'>Equal Share -{{ 100 - responseDetails.answer }}%</span>
+          <span *ngIf='responseDetails.answer === CONTRIBUTION_POINT_NOT_SUBMITTED'>Not Rated</span>
         </span>
       </ng-template>
     </label>

--- a/src/web/app/components/question-types/question-edit-answer-form/contribution-question-edit-answer-form.component.html
+++ b/src/web/app/components/question-types/question-edit-answer-form/contribution-question-edit-answer-form.component.html
@@ -1,17 +1,27 @@
 <div class="row">
   <div class="col-lg-5 col-md-12 col-sm-6 col-xs-12">
-    <select class="form-control form-select"
-            [ngClass]="{'color-positive': responseDetails.answer >= 100,
-              'color-negative': responseDetails.answer < 100 && responseDetails.answer !== CONTRIBUTION_POINT_NOT_SURE && responseDetails.answer !== CONTRIBUTION_POINT_NOT_SUBMITTED,
-              'fw-bold': responseDetails.answer === 100,
-              'color-black': responseDetails.answer === CONTRIBUTION_POINT_NOT_SURE}"
-            [ngModel]="responseDetails.answer" (ngModelChange)="triggerResponseDetailsChange('answer', $event)" [disabled]="isDisabled" [attr.aria-label]="getAriaLabel()">
-      <option [ngValue]="CONTRIBUTION_POINT_NOT_SUBMITTED"></option>
-      <option *ngFor="let point of contributionQuestionPoints" [ngValue]="point"
-              [ngClass]="{'color-positive': point >= 100,
-                'color-negative': point < 100,
-                'fw-bold': point === 100}">{{ point | contributionPointDescription }}</option>
-      <option *ngIf="questionDetails.isNotSureAllowed" [ngValue]="CONTRIBUTION_POINT_NOT_SURE" class="color-black">Not Sure</option>
-    </select>
+    <label for="contributionRange" class="form-label" 
+    [ngClass] = "{
+      'color-positive': responseDetails.answer >= 100, 
+      'color-negative': responseDetails.answer < 100, 
+      'fw-bold': responseDetails.answer === 100,
+      'color-black' : responseDetails.answer === CONTRIBUTION_POINT_NOT_SUBMITTED || responseDetails.answer === CONTRIBUTION_POINT_NOT_SURE
+    }">
+      <span *ngIf='responseDetails.answer === CONTRIBUTION_POINT_NOT_SURE && questionDetails.isNotSureAllowed; else elseBlock'>Not Sure</span>
+      <ng-template #elseBlock>
+        <span>Equal Share
+          <span *ngIf='responseDetails.answer > 100'> +{{ responseDetails.answer - 100 }}%</span>
+          <span *ngIf='responseDetails.answer < 100 && responseDetails.answer !== CONTRIBUTION_POINT_NOT_SUBMITTED'> -{{ 100 - responseDetails.answer }}%</span>
+        </span>
+      </ng-template>
+    </label>
+    <input type="range" class="form-range" min="0" max="200" value="100" step="5"
+      [ngModel]="responseDetails.answer" (ngModelChange) ="triggerResponseDetailsChange('answer', $event)"
+      [disabled]="isDisabled || responseDetails.answer === CONTRIBUTION_POINT_NOT_SURE" [attr.aria-label]="getAriaLabel()">
+    <label for="notSureCheckBox" class="form-label" *ngIf="questionDetails.isNotSureAllowed">Not Sure?</label>
+    <input type="hidden" name="toggle" [ngModel]="responseDetails.answer">
+    <input type="checkbox" class="form-check-input ms-3" [checked]="responseDetails.answer === CONTRIBUTION_POINT_NOT_SURE"
+      (change) ="triggerResponseDetailsChange('answer', responseDetails.answer === CONTRIBUTION_POINT_NOT_SURE ? 100 : CONTRIBUTION_POINT_NOT_SURE)"
+      *ngIf="questionDetails.isNotSureAllowed">
   </div>
 </div>


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/process.html#step-4-submit-a-pr. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
### Rational
As a previous user of TEAMMATES while I was taking CS2103T, whenever I rate my teammates' contributions, I find it a little troublesome to scroll through over 40 options to pick the appropriate share for each teammate. 
In addition, having a dropdown box does not provide a perspective of the share assigned to each teammate as all the shares are shown in absolute values. 
### Improvement
I changed the dropdown box and replaced it with a range slider. 
With this change, it removes the large number of options that the user has to choose from and they can slide to pick the appropriate share for each teammate. 
Also, the range slider will provide a better perspective on the user's choice as the user can compare the share chosen by looking at the slider thumb for each teammate.
<!-- If the solution includes any UI changes, attach screenshots of the new UI. --> 
### Screen shot of slider
<img width="904" alt="image" src="https://github.com/rexong/teammates/assets/66376253/73094284-8c05-40b1-a894-29813ee7f21c">

### Screen Recording
Watch the screen recording [here](https://github.com/rexong/teammates/assets/66376253/6560a103-e483-445a-b504-c60852a10def)